### PR TITLE
add rag system schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,17 @@ enum ReportStatus {
   DISMISSED
 }
 
+enum DocumentStatus {
+  UPLOADED // can upload but choose not to process for now
+  PROCESSING
+  INDEXED
+  FAILED
+}
+
+enum DocumentType {
+  SLIDES
+}
+
 model User {
   id        String   @id @default(uuid())
   createdAt DateTime
@@ -96,6 +107,9 @@ model User {
   reportsSubmitted  Report[]           @relation("ReportedBy")
   reportsReceived   Report[]           @relation("ReportedUser")
   reportsResolved   Report[]           @relation("ResolvedBy")
+
+  // RAG document system
+  uploadedDocuments Document[]
 
   @@map("users")
 }
@@ -195,6 +209,7 @@ model Subject {
   enrollments Enrollment[]
   moderators  SubjectModerator[]
   userPoints  UserPoints[]
+  documents   Document[]
 
   @@unique([code, collegeId])
   @@index([collegeId])
@@ -214,8 +229,10 @@ model Chapter {
   subject            Subject             @relation(fields: [subjectId], references: [id], onDelete: Cascade)
   content            Content[]
   chapterCompletions ChapterCompletion[]
+  documents          Document[]
 
   @@unique([subjectId, sequence])
+  @@unique([id, subjectId])
   @@index([subjectId])
   @@map("chapters")
 }
@@ -546,4 +563,91 @@ model UserPoints {
   @@index([subjectId, earnedAt]) // for subject leaderboards
   @@index([earnedAt]) // for global leaderboards
   @@map("user_points")
+}
+
+// RAG SYSTEM
+
+// TODO: Currently focused on course slides for MVP.
+// Future expansion: user-uploaded past exams, assignments, open-domain books
+model Document {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  title        String
+  description  String?
+  documentType DocumentType   @default(SLIDES) // for future filtering (exams, assignments, etc.)
+  status       DocumentStatus @default(UPLOADED)
+  fileName     String
+  fileSize     BigInt
+  mimeType     String
+
+  fileUrl String
+
+  processingError String?
+  processedAt     DateTime?
+  retryCount      Int       @default(0)
+  totalChunks     Int       @default(0)
+  totalPages      Int?
+  totalImages     Int       @default(0)
+
+  subjectId    Int
+  chapterId    Int?
+  uploadedById String
+
+  subject    Subject         @relation(fields: [subjectId], references: [id], onDelete: Cascade)
+  chapter    Chapter?        @relation(fields: [chapterId, subjectId], references: [id, subjectId], onDelete: Cascade)
+  uploadedBy User            @relation(fields: [uploadedById], references: [id], onDelete: Cascade)
+  chunks     DocumentChunk[]
+  images     DocumentImage[]
+
+  @@index([subjectId, status])
+  @@index([chapterId])
+  @@index([uploadedById])
+  @@index([status])
+  @@map("documents")
+}
+
+model DocumentChunk {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  chunkText  String
+  chunkIndex Int
+  pageNumber Int? // primary/starting page (chunks may span multiple pages)
+
+  vectorId String // reference to vector database entry
+
+  documentId String
+
+  document Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
+
+  @@unique([documentId, chunkIndex])
+  @@index([documentId])
+  @@index([vectorId])
+  @@map("document_chunks")
+}
+
+model DocumentImage {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  imageUrl      String
+  pageNumber    Int
+  caption       String?
+  aiDescription String?
+  width         Int?
+  height        Int?
+  mimeType      String
+  fileSize      Int?
+
+  documentId String
+
+  document Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
+
+  @@index([documentId, pageNumber])
+  @@index([documentId])
+  @@map("document_images")
 }


### PR DESCRIPTION
This pull request introduces a new RAG (Retrieval-Augmented Generation) document system to the Prisma schema, enabling structured storage and processing of course documents such as slides. The main changes include the creation of new models for documents, document chunks, and document images, as well as updates to existing models to support document uploads and associations with users, subjects, and chapters.

**RAG Document System Integration:**

* Added new enums `DocumentStatus` and `DocumentType` to represent the processing state and type of documents.
* Introduced the `Document`, `DocumentChunk`, and `DocumentImage` models to store uploaded documents, their processed text chunks, and associated images, respectively. These models include fields for metadata, processing status, and relationships to users, subjects, and chapters.

**Schema Relationships and Associations:**

* Updated the `User` model to include a relation to uploaded documents via the new `uploadedDocuments` field.
* Updated the `Subject` and `Chapter` models to associate them with documents through new `documents` fields, allowing documents to be linked to specific subjects and chapters. [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR212) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR232-R235)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add a document library tied to subjects and chapters, allowing users to upload files with titles, descriptions, and file details.
  - Show document processing status, completion time, and any errors.
  - Automatically split documents into readable chunks to improve viewing and future discovery.
  - Generate per-page image previews with optional captions and descriptions.
  - Track who uploaded each document for clearer ownership and management.
  - Faster navigation and filtering of documents by subject, chapter, and status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->